### PR TITLE
Add bash to the container and add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules/
+.husky

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-## rif-relay-contracts dockerfile
+# rif-relay-contracts dockerfile
 FROM node:12-alpine AS compiler
-RUN apk add --no-cache build-base git
+RUN apk add --no-cache build-base git bash
 WORKDIR /usr/src/app
-COPY package*.json ./
-COPY scripts ./
-COPY truffle.js ./
-RUN npm install
-RUN npm install truffle -g
 COPY . ./
-#RUN npx truffle migrate --network regtest
+RUN npm install
 RUN npm run deploy regtest
-


### PR DESCRIPTION
## Disclaimer
Although these changes fix the problem where the script wasn't found when we tried to execute it, it cannot be considered completed nor optimized. It is intended to be used as a starting point. It still raises an error since that the script `npm run deploy` cannot be executed without an RSKj node available at the address specified in the `truffle.js`

## What

- Add the bash package to the node:12-alpine container used to compile the contracts
- add the .dockerignore file

## Why

- we need to dockerize this project to be used where releasing the server
